### PR TITLE
Move upstream Shimmer to pod dependency

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "ios/Shimmer"]
-	path = ios/Shimmer
-	url = https://github.com/facebook/Shimmer.git

--- a/.npmignore
+++ b/.npmignore
@@ -6,11 +6,6 @@
 node_modules
 
 Example
-ios/Shimmer/Examples
-ios/Shimmer/FBShimmering.xcworkspace
-ios/Shimmer/shimmer.gif
-ios/Shimmer/Shimmer.podspec
-ios/Shimmer/CONTRIBUTING.md
 xcuserdata
 
 .editorconfig

--- a/README.md
+++ b/README.md
@@ -2,23 +2,35 @@
 
 Simple shimmering effect in React Native. Based on [Shimmer](https://github.com/facebook/Shimmer)/[shimmer-android](https://github.com/facebook/shimmer-android).
 
+Forked from https://github.com/oblador/react-native-shimmer to play nicely with other code in the
+same Xcode project that is also dependent on the upstream Shimmer library (avoiding code duplication
+build errors on iOS/Xcode). It does so by removing the git submodule for upstream Shimmer, instead
+depending on it via `podspec` config.
+
 ![Shimmer](https://github.com/facebook/Shimmer/blob/master/shimmer.gif?raw=true)
 
 ## Installation
 
-`$ yarn add react-native-shimmer`
+`$ npm install --save git://github.com/humandx/react-native-shimmer.git`
 
-### Option: With `react-native link`
+### Installation for iOS
 
-`$ react-native link react-native-shimmer`
+See notes above for why installation via [CocoaPods](https://cocoapods.org/) is required. To
+install, add the following to your `Podfile` and run `pod update`:
 
-### Option: Manually
+```
+pod 'react-native-shimmer', :path => 'node_modules/react-native-shimmer'
+```
 
-#### iOS
+#### Installation for Android
 
-Add `ios/RNShimmer.xcodeproj` to **Libraries** and add `libRNShimmer.a` to **Link Binary With Libraries** under **Build Phases**. [More info and screenshots about how to do this is available in the React Native documentation](http://facebook.github.io/react-native/docs/linking-libraries-ios.html#content).
+Unfortunately, requiring the `pod` approach above for iOS makes things a little less convenient for
+Android. There are 2 options:
 
-#### Android
+1. Run `react-native link react-native-shimmer`, which will link everything for Android. However,
+   you then need to manually remove the changes made by this command to the entire `iOS/` tree.
+
+2. Install manually as below for Android:
 
 * Edit `android/settings.gradle` to look like this (without the +):
 
@@ -68,13 +80,6 @@ package com.myapp;
 }
 ```
 
-### Option: With [CocoaPods](https://cocoapods.org/)
-
-Add the following to your `Podfile` and run `pod update`:
-
-```
-pod 'react-native-shimmer', :path => 'node_modules/react-native-shimmer'
-```
 
 ## Usage
 
@@ -106,4 +111,4 @@ import Shimmer from 'react-native-shimmer';
 
 ## License
 
-[MIT License](http://opensource.org/licenses/mit-license.html). Shimmer is under BSD license. © Joel Arvidsson 2016 - present
+[MIT License](http://opensource.org/licenses/mit-license.html).

--- a/react-native-shimmer.podspec
+++ b/react-native-shimmer.podspec
@@ -10,10 +10,11 @@ Pod::Spec.new do |s|
   s.author          = { "Joel Arvidsson" => "joel@oblador.se" }
   s.summary         = 'Simple shimmering effect for React Native.'
   s.source          = { :git => 'https://github.com/oblador/react-native-shimmer.git', :tag => "v#{s.version}" }
-  s.source_files    = 'ios/{,Shimmer/FBShimmering/}*.{h,m}'
+  s.source_files    = 'ios/*.{h,m}'
   s.preserve_paths  = "**/*.js"
   s.requires_arc    = true
   s.platform        = :ios, "7.0"
 
   s.dependency 'React'
+  s.dependency 'Shimmer'
 end


### PR DESCRIPTION
* Remove git submodule for upstream Shimmer repo.
* Remove ios/Shimmer directory.
* Remove npm ignore rules that are no longer necessary since
  ios/Shimmer has been removed.
* Update podspec to explicitly require Shimmer pod.
* Update README to reflect the above changes.